### PR TITLE
Add resp.text to debuglog in _handle_response

### DIFF
--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -107,7 +107,7 @@ class QNAPStats(object):
         if resp.headers["Content-Type"] != "text/xml":
             # JSON requests not currently supported
             return None
-
+        self._debuglog("Response Text: " + resp.text)
         data = xmltodict.parse(resp.content, force_list=force_list)['QDocRoot']
 
         auth_passed = data['authPassed']


### PR DESCRIPTION
Makes it easier to see why calls are failing.