### PR TITLE
added error handling to account for sharenames with no folder

### DIFF
--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -173,7 +173,7 @@ class QNAPStats(object):
                         used_size = int(folder["used_size"])
                         volumes[key]["folders"].append({"sharename": sharename, "used_size": used_size})
                     except Exception as e:
-                        print(e.message, e.args)
+                        print(e.args)
                         pass
 
         return volumes

--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -168,9 +168,13 @@ class QNAPStats(object):
             if len(folder_elements) > 0:
                 volumes[key]["folders"] = []
                 for folder in folder_elements:
-                    sharename = folder["sharename"]
-                    used_size = int(folder["used_size"])
-                    volumes[key]["folders"].append({"sharename": sharename, "used_size": used_size})
+                    try:
+                        sharename = folder["sharename"]
+                        used_size = int(folder["used_size"])
+                        volumes[key]["folders"].append({"sharename": sharename, "used_size": used_size})
+                    except Exception as e:
+                        print(e.message, e.args)
+                        pass
 
         return volumes
 


### PR DESCRIPTION
This is a quick fix to mitigate throwing an error when looping sharenames for folders and "None" is returned.