### PR TITLE
If QNAP not have Volumes the app crash

### DIFF
--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -154,7 +154,7 @@ class QNAPStats:
             }
 
             id_map[key] = label
-            
+
         for vol in resp["volumeList"]["volume"]:
             id_number = vol["volumeDisks"]
 

--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -154,9 +154,9 @@ class QNAPStats:
             }
 
             id_map[key] = label
-
-        for vol in resp["volumeUseList"]["volumeUse"]:
-            id_number = vol["volumeValue"]
+            
+        for vol in resp["volumeList"]["volume"]:
+            id_number = vol["volumeDisks"]
 
             # Skip any system reserved volumes
             if id_number not in id_map.keys():


### PR DESCRIPTION
Hi,
if Qnap not have the classic volume but have only the replica volume the program generate the exception because not found the xml tag.
I changed the tag and now the qnap works with qnap with volumes and without volumes.

Please check if what I said is true.

This is the result with error of debug:

```
DEBUG: Creating new session DEBUG: POST to URL: http://192.168.11.7:8080/cgi-bin/authLogin.cgi DEBUG: Request executed: 200 DEBUG: Response Text:
<?xml version="1.0" encoding="UTF-8"?>
<QDocRoot version="1.0">
	<doQuick>
		<![CDATA[]]></doQuick>
	<is_booting>
		<![CDATA[0]]></is_booting>
	<mediaReady>
		<![CDATA[1]]></mediaReady>
	<shutdown_info>
		<type>
			<![CDATA[-1]]></type>
		<timestamp>
			<![CDATA[0]]></timestamp>
		<duration>
			<![CDATA[0]]></duration>
	</shutdown_info>
	<SMBFW>
		<![CDATA[1]]></SMBFW>
	<hero_model>
		<![CDATA[0]]></hero_model>
	<qts_mode_type>
		<![CDATA[0]]></qts_mode_type>
	<authPassed>
		<![CDATA[1]]></authPassed>
	<authSid>
		<![CDATA[t3tryynz]]></authSid>
	<pw_status>
		<![CDATA[0]]></pw_status>
	<isAdmin>
		<![CDATA[1]]></isAdmin>
	<username>
		<![CDATA[admin]]></username>
	<groupname>
		<![CDATA[administrators]]></groupname>
	<ts>
		<![CDATA[73096820]]></ts>
	<fwNotice>
		<![CDATA[0]]></fwNotice>
	<SUID>
		<![CDATA[1bc35f0d0d904969cfa976f72010f3cd]]></SUID>
	<title>
		<![CDATA[]]></title>
	<content>
		<![CDATA[]]></content>
	<psType>
		<![CDATA[1]]></psType>
	<standard_massage>
		<![CDATA[]]></standard_massage>
	<standard_color>
		<![CDATA[#ffffff]]></standard_color>
	<standard_size>
		<![CDATA[12px]]></standard_size>
	<standard_bg_style>
		<![CDATA[fill]]></standard_bg_style>
	<showVersion>
		<![CDATA[0]]></showVersion>
	<show_link>
		<![CDATA[1]]></show_link>
	<cuid>
		<![CDATA[137c605b51b297d143dec7aa2d0346ed]]></cuid>
</QDocRoot>
DEBUG: GET from URL: http://192.168.11.7:8080/cgi-bin/management/chartReq.cgi?chart_func=disk_usage&disk_select=all&include=all DEBUG: Appending access_token (SID: t3tryynz) to url DEBUG: Request executed: 200 DEBUG: Response Text:
<?xml version="1.0" encoding="UTF-8"?>
<QDocRoot version="1.0">
	<authPassed>
		<![CDATA[1]]></authPassed>
	<model>
		<modelName>
			<![CDATA[TS-X77U]]></modelName>
		<internalModelName>
			<![CDATA[TS-X77]]></internalModelName>
		<platform>
			<![CDATA[TS-NASX86]]></platform>
		<platform_ex>
			<![CDATA[X86_SUMMITRIDGE]]></platform_ex>
		<customModelName>
			<![CDATA[]]></customModelName>
		<displayModelName>
			<![CDATA[TS-1677XU-RP]]></displayModelName>
		<sas_model>
			<![CDATA[0]]></sas_model>
		<storage_v2>1</storage_v2>
		<encryptfsSupported>
			<![CDATA[1]]></encryptfsSupported>
		<is_zfs>
			<![CDATA[0]]></is_zfs>
		<node>
			<![CDATA[]]></node>
		<dual_node>
			<![CDATA[]]></dual_node>
	</model>
	<firmware>
		<version>
			<![CDATA[4.5.2]]></version>
		<number>
			<![CDATA[1594]]></number>
		<build>
			<![CDATA[20210302]]></build>
		<patch>
			<![CDATA[0]]></patch>
		<buildTime>
			<![CDATA[2021/03/02]]></buildTime>
	</firmware>
	<rfs_bits>
		<![CDATA[64]]></rfs_bits>
	<specVersion>
		<![CDATA[1.0]]></specVersion>
	<hostname>
		<![CDATA[QNAP06]]></hostname>
	<DemoSiteSuppurt>
		<![CDATA[no]]></DemoSiteSuppurt>
	<customLogo>
		<customFrontLogo>
			<![CDATA[]]></customFrontLogo>
		<customLoginLogo>
			<![CDATA[]]></customLoginLogo>
	</customLogo>
	<volumeList>
		<volume>
			<volumeStat>
				<![CDATA[mirror]]></volumeStat>
			<volumeDisks>
				<![CDATA[ 1,2]]></volumeDisks>
			<volumeStatus>
				<![CDATA[0]]></volumeStatus>
			<Progress>
				<![CDATA[100]]></Progress>
			<volumeType>
				<![CDATA[4]]></volumeType>
			<volumeValue>
				<![CDATA[1]]></volumeValue>
			<freeSize>
				<![CDATA[0]]></freeSize>
			<fstype>
				<![CDATA[0]]></fstype>
			<volumeLabel>
				<![CDATA[V_DataVolUsers]]></volumeLabel>
			<FSRVP_support>
				<![CDATA[0]]></FSRVP_support>
			<edge_cache_support>
				<![CDATA[0]]></edge_cache_support>
			<edge_cache_type>
				<![CDATA[-1]]></edge_cache_type>
			<FolderCounter>
				<![CDATA[0]]></FolderCounter>
			<is_legacy_volume>
				<![CDATA[0]]></is_legacy_volume>
			<is_default_volume>
				<![CDATA[0]]></is_default_volume>
			<pool_vjbod>
				<![CDATA[0]]></pool_vjbod>
			<encryptfs_bool>
				<![CDATA[0]]></encryptfs_bool>
			<encryptfs_active_bool>
				<![CDATA[0]]></encryptfs_active_bool>
			<encryptfs_key_flag>
				<![CDATA[N]]></encryptfs_key_flag>
		</volume>
		<volume>
			<volumeStat>
				<![CDATA[mirror]]></volumeStat>
			<volumeDisks>
				<![CDATA[ 1,2]]></volumeDisks>
			<volumeStatus>
				<![CDATA[0]]></volumeStatus>
			<Progress>
				<![CDATA[100]]></Progress>
			<volumeType>
				<![CDATA[4]]></volumeType>
			<volumeValue>
				<![CDATA[2]]></volumeValue>
			<freeSize>
				<![CDATA[0]]></freeSize>
			<fstype>
				<![CDATA[0]]></fstype>
			<volumeLabel>
				<![CDATA[V_DataVol_Xray]]></volumeLabel>
			<FSRVP_support>
				<![CDATA[0]]></FSRVP_support>
			<edge_cache_support>
				<![CDATA[0]]></edge_cache_support>
			<edge_cache_type>
				<![CDATA[-1]]></edge_cache_type>
			<FolderCounter>
				<![CDATA[0]]></FolderCounter>
			<is_legacy_volume>
				<![CDATA[0]]></is_legacy_volume>
			<is_default_volume>
				<![CDATA[0]]></is_default_volume>
			<pool_vjbod>
				<![CDATA[0]]></pool_vjbod>
			<encryptfs_bool>
				<![CDATA[0]]></encryptfs_bool>
			<encryptfs_active_bool>
				<![CDATA[0]]></encryptfs_active_bool>
			<encryptfs_key_flag>
				<![CDATA[N]]></encryptfs_key_flag>
		</volume>
	</volumeList>
	<volumeUseList/>
</QDocRoot>
("'NoneType' object is not subscriptable",) Traceback (most recent call last): File "./debug.py", line 32, in
<module>qnap.get_volumes() File "/usr/local/lib/python3.8/dist-packages/qnapstats/qnap_stats.py", line 155, in get_volumes for vol in resp["volumeUseList"]["volumeUse"]: TypeError: 'NoneType' object is not subscriptable
```