### PR TITLE
Fix for firmware version

### DIFF
--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -334,7 +334,8 @@ class QNAPStats:
         if resp is None:
             return None
 
-        new_version = resp["func"]["ownContent"]["newVersion"]
+        new_version = None
+        try: new_version = resp["func"]["ownContent"]["newVersion"]
         if new_version is None or len(new_version) == 0:
             return None
 


### PR DESCRIPTION
I am finding that if there is no new firmware update available, then there is no “newVersion” field in the response XML. Therefore, instead of failing on error, just return None.