### PR TITLE
Adding system fan monitoring

### DIFF
--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -283,8 +283,7 @@ class QNAPStats:
             sysfan = "sysfan" + str(sysfan_index)
             details["sysfans"][sysfan] = {
                 "speed": int(root["sysfan" + i]),
-                "stat": int(root["sysfan" + i + "_stat"]),
-                "fail": int(root["sysfan_fail" + i ])
+                "status": "alert" if int(root["sysfan" + i + "_stat"]) == -1 else "ok"
             }
         
 

--- a/qnapstats/qnap_stats.py
+++ b/qnapstats/qnap_stats.py
@@ -257,6 +257,7 @@ class QNAPStats:
             },
             "nics": {},
             "dns": [],
+            "sysfans": {},
         }
 
         nic_count = int(root["nic_cnt"])
@@ -275,6 +276,17 @@ class QNAPStats:
                 "tx_packets": int(root["tx_packet" + i]),
                 "err_packets": int(root["err_packet" + i])
             }
+            
+        sysfan_count = int(root["sysfan_count"])
+        for sysfan_index in range(sysfan_count):
+            i = str(sysfan_index + 1)
+            sysfan = "sysfan" + str(sysfan_index)
+            details["sysfans"][sysfan] = {
+                "speed": int(root["sysfan" + i]),
+                "stat": int(root["sysfan" + i + "_stat"]),
+                "fail": int(root["sysfan_fail" + i ])
+            }
+        
 
         dnsInfo = root.get("dnsInfo")
         if dnsInfo:


### PR DESCRIPTION
Hi,
I've added the monitoring of system fan(s) speed and status, for me was useful for manage the speed of the fans for controlling the temperature, because the Qnap standard way to control the speed (smart) is not working as supposed.
I know that there are models with different type of fans (eg. CPU fan) but mine model has only one system fan.
Feel free to gave me some advice about my pull request.
Thank you
Alessandro