### PR TITLE
Fix Pypi publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Build and publish distributions to PyPI
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - '*.*.*'
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Allows to publish to Pypi on auto created releases by just pushing a tag.

Without this settings, only manually created releases are pushed to Pypi.